### PR TITLE
Pager-Duty Integration Test 

### DIFF
--- a/integrations/pager-duty-test-ol/README.MD
+++ b/integrations/pager-duty-test-ol/README.MD
@@ -1,0 +1,2 @@
+just a test to try and get an incident report on PagerDuty when a flag is changed in LauchDarkly.
+

--- a/integrations/pager-duty-test-ol/assets/images/horizontal.svg
+++ b/integrations/pager-duty-test-ol/assets/images/horizontal.svg
@@ -1,0 +1,4 @@
+<svg width="500" height="500" viewBox="0 0 500 500" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="250" cy="250" r="250" fill="#A51E1E"/>
+<ellipse cx="318.75" cy="338.393" rx="108.036" ry="108.036" fill="white"/>
+</svg>

--- a/integrations/pager-duty-test-ol/assets/images/square.svg
+++ b/integrations/pager-duty-test-ol/assets/images/square.svg
@@ -1,0 +1,4 @@
+<svg width="500" height="500" viewBox="0 0 500 500" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="250" cy="250" r="250" fill="#A51E1E"/>
+<ellipse cx="318.75" cy="338.393" rx="108.036" ry="108.036" fill="white"/>
+</svg>

--- a/integrations/pager-duty-test-ol/manifest.json
+++ b/integrations/pager-duty-test-ol/manifest.json
@@ -1,0 +1,66 @@
+{
+  "name": "PagerDuty",
+  "version": "1.0.0",
+  "overview": "Test for PagerDuty",
+  "description": "Send Flag data to PagerDuty to create an incident.",
+  "author": "oliverlinton.uk",
+  "supportEmail": "oliverwlinton@gmail.com",
+  "links": {
+    "site": "https://pagerduty.com",
+    "privacyPolicy": "https://pagerduty.com/privacy"
+  },
+  "categories": ["monitoring"],
+  "icons": {
+    "square": "assets/images/square.svg",
+    "horizontal": "assets/images/horizontal.svg"
+  },
+  "requiresOAuth": false,
+  "formVariables": [
+    {
+        "key": "endpointUrl",
+        "name": "Webhook endpoint URL",
+        "description": "Enter the URL to the webhook endpoint",
+        "defaultValue": "*",
+        "type": "uri",
+        "placeholder": "https://example.com"
+        
+    },
+    {
+        "key": "apiToken",
+        "name": "API Key",
+        "description": "Enter your [API key](https://developer.pagerduty.com/api-reference/ZG9jOjUxNzk5-changelog) here",
+        "type": "string",
+        "isSecret": true,
+        "placeholder": "1234ae"
+    }
+  ],
+  "capabilities": {
+    "auditLogEventsHook": {
+        "endpoint": {
+            "url": "{{endpointUrl}}",
+            "method": "POST",
+            "headers": [
+                {
+                    "name": "Content-Type",
+                    "value": "application/json"
+                },
+                {
+                    "name": "Authorization",
+                    "value": "Bearer {{apiToken}}"
+                }
+            ]
+        },
+        "templates": {
+            "flag": "templates/flag.json.hbs"
+        },
+        "defaultPolicy": [
+            {
+                "effect": "allow",
+                "resources": ["proj/*:env/production:flag/*"],
+                "actions": ["*"]
+            }
+        ]
+    }
+}  
+}
+

--- a/integrations/pager-duty-test-ol/manifest.json
+++ b/integrations/pager-duty-test-ol/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "PagerDuty",
   "version": "1.0.0",
-  "overview": "Test for PagerDuty",
+  "overview": "Test for PagerDuty.",
   "description": "Send Flag data to PagerDuty to create an incident.",
   "author": "oliverlinton.uk",
   "supportEmail": "oliverwlinton@gmail.com",
@@ -20,7 +20,6 @@
         "key": "endpointUrl",
         "name": "Webhook endpoint URL",
         "description": "Enter the URL to the webhook endpoint",
-        "defaultValue": "*",
         "type": "uri",
         "placeholder": "https://example.com"
         

--- a/integrations/pager-duty-test-ol/templates/default.json.hbs
+++ b/integrations/pager-duty-test-ol/templates/default.json.hbs
@@ -1,0 +1,7 @@
+{
+  "title": "{{title.markdown}}",
+  "text": "{{details.plainText}}",
+  "date_happened": "{{timestamp.seconds}}",
+  "tags": ["any", "arbitrary", "tag"],
+  "source_type_name": "example.com"
+}

--- a/integrations/pager-duty-test-ol/templates/flag.json.hbs
+++ b/integrations/pager-duty-test-ol/templates/flag.json.hbs
@@ -1,0 +1,7 @@
+    {
+
+      "eventType": "LaunchDarkly",
+      "timestamp": {{timestamp.milliseconds}},
+      "project": "{{project.name}}",
+      "title": "{{name}}"
+    }

--- a/integrations/pager-duty-test-ol/templates/flag.json.hbs
+++ b/integrations/pager-duty-test-ol/templates/flag.json.hbs
@@ -1,7 +1,8 @@
-    {
-
-      "eventType": "LaunchDarkly",
-      "timestamp": {{timestamp.milliseconds}},
-      "project": "{{project.name}}",
-      "title": "{{name}}"
-    }
+{
+    "title": "{{title.markdown}}",
+    "text": "{{details.plainText}}",
+    "date_happened": "{{timestamp.seconds}}",
+    "tags": ["any", "arbitrary", "tag"],
+    "color": "{{formVariables.color}}",
+    "extra": "This is a feature flag"
+}

--- a/integrations/pager-duty-test-ol/templates/flag.json.hbs
+++ b/integrations/pager-duty-test-ol/templates/flag.json.hbs
@@ -3,6 +3,5 @@
     "text": "{{details.plainText}}",
     "date_happened": "{{timestamp.seconds}}",
     "tags": ["any", "arbitrary", "tag"],
-    "color": "{{formVariables.color}}",
     "extra": "This is a feature flag"
 }


### PR DESCRIPTION
**Requirements**

- [ x ] I have followed the repository's [pull request submission guidelines](../blob/master/README.md#submitting-pull-requests)
- [ x ] I have updated my user documentation
- [ x ] I have updated my developer documentation (my integration README)

**Intended availability**

If you're adding a new integration, let us know if you are a community member or a partner.

_community member_

If you are a partner, your integration will be available to all customers.

If you're part of the community and submitting an integration for your own purposes or internal teams, specify your company name so that we can verify your identity and enable the integration for your account.

_Company Name : TurbidRobin_

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

If you're adding a new integration, provide some context into how LaunchDarkly and the third-party service should interact.

_Testing to see if this will allow the ability to create incidents from flags being changed without the need of a third party application._

If you're modifying an existing integration, provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

_Third party apps such as new relic or data dog_ 

If you're modifying an existing integration, provide a clear and concise description of any alternative solutions or features you've considered.

**Provide a request preview**

Include the output from running `npm run preview <INTEGRATION_NAME>`.

URL:    $ENDPOINTURL
METHOD: POST
HEADER: Content-Type: application/json
HEADER: Authorization: Bearer $APITOKEN
BODY:   targeting-rule-update.json
{
    "title": "[Henrietta Powell](mailto:testing@launchdarkly.com) updated the flag [Demo flag](https://app.launchdarkly.com/default/production/features/demo-flag) in &#x60;Production&#x60;",
    "text": "Removed &#x27;Ushki&#x27; from the variation &#x27;true&#x27;\nDecreased the rollout from &#x27;50%&#x27; to &#x27;43%&#x27; for the rule \n  If &#x27;email&#x27; ends with &#x27;.edu&#x27;\n  serve &#x27;43%&#x27; &#x27;true&#x27;\n",
    "date_happened": "1635813031",
    "tags": ["any", "arbitrary", "tag"],
    "extra": "This is a feature flag"
}

**Additional context**

Add any other context about the pull request here.

_Just a test to see if this would allow PagerDuty and Launchdarkly to work together without the need of third party applications._ 