### PR TITLE
/api/v2/segment-target -> /api/v2/segment-targets to match prod environment

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -44,14 +44,14 @@ The LaunchDarkly Integration Validation Server exposes the following endpoints:
 
 | Endpoint           | Method | Description                                   |
 |--------------------|--------|-----------------------------------------------|
-| `/api/v2/segment-target/:integrationKey`                | POST    | Simulates processing a synced segment data from a Customer Data Provider (CDP). Replace `:integrationKey` with the name of the directory that you are adding to the `integration-framework` repository under `integrations/`. |
+| `/api/v2/segment-targets/:integrationKey`               | POST    | Simulates processing a synced segment data from a Customer Data Provider (CDP). Replace `:integrationKey` with the name of the directory that you are adding to the `integration-framework` repository under `integrations/`. |
 
 ### Example usage
 
 To validate that a segment from a Customer Data Platform (CDP) will be successfully parsed and processed, you can make the following curl request:
 
 ```shell
-curl --location 'http://localhost:3000/api/v2/segment-target/example-integration-key' \
+curl --location 'http://localhost:3000/api/v2/segment-targets/example-integration-key' \
 --header 'Content-Type: application/json' \
 --data '{
   "environmentId": "example-client-side-ID",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -12,7 +12,7 @@ const port = 3000;
 
 app.use(express.json());
 
-app.post('/api/v2/segment-target/:integrationKey', async (req, res) => {
+app.post('/api/v2/segment-targets/:integrationKey', async (req, res) => {
   const key = req.params.integrationKey;
 
   const body = req.body;


### PR DESCRIPTION
**Requirements**

- [x] I have followed the repository's [pull request submission guidelines](../blob/main/README.md#submitting-pull-requests)
- [x] I have updated my user documentation
- [x] I have updated my developer documentation (my integration README)
- [x] I have submitted the [Become a Partner](https://launchdarkly.com/partners/) form

**Describe the solution you've provided**

Daniel and I were testing Census integration end to end and figured that the integration framework uses /api/v2/segment-target while the production environment accepts requests on /api/v2/segment-targets. `segment-target` returns a generic 404 page, and `segment-targets` accepts synced segments as expected.

Grep output before the change:
```
> rg segment-target 
server/src/index.ts
15:app.post('/api/v2/segment-targets/:integrationKey', async (req, res) => {

server/README.md
47:| `/api/v2/segment-target/:integrationKey`                | POST    | Simulates processing a synced segment data from a Customer Data Provider (CDP). Replace `:integrationKey` with the name of the directory that you are adding to the `integration-framework` repository under `integrations/`. |
54:curl --location 'http://localhost:3000/api/v2/segment-target/example-integration-key' \
```
