### PR TITLE
Update GitHub Action SHA to latest version

### DIFF
--- a/.github/workflows/jira_linker.yml
+++ b/.github/workflows/jira_linker.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'launchdarkly/integration-framework-private'
     steps:
-      - uses: launchdarkly-labs/ld-gh-actions-jira@7d61c90e8fc29c3ce8e3f0fb55d963afd084a359
+      - w6139161c434b291910fe7f8925d6c6f1026344
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           jira-base-url: https://launchdarkly.atlassian.net


### PR DESCRIPTION
This PR updates the GitHub Action SHA to the latest version for security and feature improvements.

Updated files:
- .github/workflows/jira_linker.yml