### PR TITLE
Update GitHub Action SHA to latest version

### DIFF
--- a/.github/workflows/jira_linker.yml
+++ b/.github/workflows/jira_linker.yml
@@ -9,9 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'launchdarkly/integration-framework-private'
     steps:
-      - uses: launchdarkly-labs/ld-gh-actions-jira@7d61c90e8fc29c3ce8e3f0fb55d963afd084a359
+      - uses: launchdarkly-labs/ld-gh-actions-jira@676139161c434b291910fe7f8925d6c6f1026344
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           jira-base-url: https://launchdarkly.atlassian.net
           jira-username: ${{ secrets.JIRA_USERNAME }}
           jira-api-token: ${{ secrets.JIRA_API_TOKEN }}
+          update-description: true


### PR DESCRIPTION
This PR makes the change to take advantage of the new `update-description` feature of [ld-gh-actions-jira](https://github.com/launchdarkly-labs/ld-gh-actions-jira). This should help reduce some of the bot comment noise on our PRs.

Updated files:
- .github/workflows/jira_linker.yml