### PR TITLE
[REL-10013] Add .trufflehogignore file to ignore false positives

### DIFF
--- a/.trufflehogignore
+++ b/.trufflehogignore
@@ -1,0 +1,3 @@
+# Ignore false positives - GitHub commit hashes in gist URLs in documentation
+docs/manifest\.md
+docs/form-variables\.md


### PR DESCRIPTION
This PR adds a .trufflehogignore file to suppress several false positives that were found in our old documentation URLs. I inspected the false positives manually to confirm they are safe to ignore.
<!-- ld-jira-link -->
---
Related Jira issue: [REL-10013: Integration Framework: configure Trufflehog to ignore false positives](https://launchdarkly.atlassian.net/browse/REL-10013)
<!-- end-ld-jira-link -->