### PR TITLE
Added jiraMetaUrl form variable to Jira integration

### DIFF
--- a/integrations/jira/manifest.json
+++ b/integrations/jira/manifest.json
@@ -35,6 +35,15 @@
       "defaultValue": ""
     },
     {
+      "key": "jiraMetaUrl",
+      "name": "Jira meta trigger URL",
+      "type": "uri",
+      "description": "Enter your Jira meta web trigger URL",
+      "isSecret": false,
+      "isOptional": true,
+      "defaultValue": ""
+    },
+    {
       "key": "secret",
       "name": "Secret",
       "description": "Enter the secret shared between Jira and LaunchDarkly",


### PR DESCRIPTION
## Describe the solution you've provided

Adds an optional `jiraMetaUrl` form variable to the Jira integration manifest. The Forge app stores its jira-meta webtrigger URL here when configuring a subscription. Gonfalon uses that URL to request Jira projects and issue types for observability’s create issue UI, instead of observability repos previous OAuth for Jira Integration. The field is optional so existing subscriptions will remain valid without it. This feature only works after the Forge integration is reconfigured (through re-saving the LD API token) so the subscription picks up jiraMetaUrl.

## Describe alternatives you've considered

- Reusing `issueCreateUrl` for meta as well: rejected, want to keep separation between the webtriggers
- Keeping Observability OAuth for project listing: rejected, flow focuses on Forge to Jira communication

**Requirements**
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/README.md#submitting-pull-requests)
- [x] I have updated my user documentation
- [ ] I have updated my developer documentation (my integration README)
- [ ] I have submitted the [Become a Partner](https://launchdarkly.com/partners/) form

**Intended availability**

N/A, not a new integration. Uses existing Jira integration, but only added change is a jiraMetaData form variable.

**Related issues**

Part of the observability repo's “Create Jira issue via Forge” work, where OAuth was removed (previously used for project/issue-type listing). Depends on PRs in `jira-forge-integration`, `gonfalon`, and `observability` repos.

**Additional context**
- Key: `jiraMetaUrl`
- Type: `uri`, optional
- Flow is as follows: Forge `createJiraSubscription` → Gonfalon `GET /api/v2/integrations/jira/meta` → Forge `jiraMetaHandler`